### PR TITLE
bump action version, break command

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,15 +6,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 20.11.0
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.11.0
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: VITE_BACKEND_URL="https://api.knur.club"  VITE_FRONTEND_URL="https://mamm0n.knur.club" npm run build
+        run: > 
+          VITE_BACKEND_URL="https://api.knur.club" 
+          VITE_FRONTEND_URL="https://mamm0n.knur.club" 
+          npm run build
       - name: Build, tag, and push image to Docker Hub
         id: build-image
         run: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,9 +6,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 20.11.0
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.11.0
       - name: Install dependencies
@@ -18,4 +18,7 @@ jobs:
       - name: Check prettier
         run: npm run prettier:prod
       - name: Build
-        run: VITE_BACKEND_URL="https://api.knur.club"  VITE_FRONTEND_URL="https://mamm0n.knur.club" npm run build
+        run: >
+          VITE_BACKEND_URL="https://api.knur.club" 
+          VITE_FRONTEND_URL="https://mamm0n.knur.club" 
+          npm run build


### PR DESCRIPTION
Hey!
Newer versions of checkout and setup_node are available so I bumped it.
Also, this build command looks too long for me so I split it into multiple. ~~Not sure if it work because I accidentally created PR here instead of in my forked repo. It can be tested in this PR.~~  Tested and works fine. 